### PR TITLE
add build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.direnv/*
+.envrc
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: inference.py",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "inference.py",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+    ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,36 @@
+{
+    "editor.formatOnSave": true,
+    "python.analysis.autoImportCompletions": true,
+    "python.analysis.useLibraryCodeForTypes": true,
+    "python.languageServer": "Pylance",
+    "ruff.nativeServer": "on",
+    "python.analysis.typeCheckingMode": "standard",
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+    "editor.renderWhitespace": "all",
+    "editor.rulers": [
+        120
+    ],
+    "workbench.colorTheme": "Default Dark Modern",
+    "files.exclude": {
+        "**/__pycache__": true,
+        "**/.venv": true,
+        "**/.mypy_cache": true,
+        "**/.pytest_cache": true,
+        "**/.vscode": false
+    },
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit"
+        }
+    },
+    "search.exclude": {
+        "**/__pycache__": true,
+        "**/.venv": true,
+        "**/.mypy_cache": true,
+        "**/.ruff_cache": true,
+        "**/.pytest_cache": true
+    }
+}

--- a/MODEL_COMPILATION.md
+++ b/MODEL_COMPILATION.md
@@ -47,18 +47,6 @@ export RUNWARE_LTX_NO_COMPILE_KERNELS=1  # Disable compilation
 
 4. **Dynamic Loading**: Kernels are attached to the module namespace dynamically after compilation
 
-### Manual Compilation
-```python
-from ltx_video.models.autoencoders.vae_patcher.kernels.compiler import compiled_kernel
-import pathlib
-
-# Compile a specific kernel
-kernel = compiled_kernel(
-    name="pixel_norm",
-    sources=["pixel_norm.cpp", "pixel_norm_cuda.cu"],
-    output_directory=pathlib.Path("/custom/output/dir")
-)
-```
 
 ### Disabling Automatic Compilation
 ```python
@@ -103,4 +91,55 @@ SOURCES = {
     ]
 }
 ```
+
+### CLI Commands
+
+To compile kernels manually, you can use the provided CLI commands:
+```bash
+python -m ltx_video --help 
+```
+
+```
+LTX Video utility commands
+
+positional arguments:
+  {compile-kernels,load-all-kernels}
+                        Available commands
+    compile-kernels     Compile CUDA kernels
+    load-all-kernels    Load all compiled CUDA kernels
+
+options:
+  -h, --help            show this help message and exit
+  --verbose             Enable verbose output (default: False)
+```
+
+**Kernel Compilation Command**
+
+```bash
+python -m ltx_video compile-kernels --arch-list=sm_70;sm_75 --kernels-dir=/path/to/kernels --force-rebuild
+```
+
+```
+usage: python -m ltx_video compile-kernels [-h] [--arch-list ARCH_LIST] [--kernels-dir KERNELS_DIR] [--force-rebuild]
+
+options:
+  -h, --help            show this help message and exit
+  --arch-list ARCH_LIST
+                        CUDA architecture list (semicolon-separated)
+  --kernels-dir KERNELS_DIR
+                        Output directory for compiled kernels
+  --force-rebuild       Force rebuild of all kernels, even if they are already compiled
+```
+
+**Testing Kernel Compilation**
+
+After compiling the kernels, they can be loaded and tested using the following command, in order to test if the kernels are loading correctly:
+
+```bash
+usage: python -m ltx_video  load-all-kernels [-h] [--kernels-dir KERNELS_DIR]
+
+options:
+  -h, --help            show this help message and exit
+  --kernels-dir KERNELS_DIR
+                        Output directory for compiled kernels
 ```

--- a/MODEL_COMPILATION.md
+++ b/MODEL_COMPILATION.md
@@ -1,0 +1,106 @@
+# LTX Video CUDA Kernel Compilation
+
+This module provides automatic compilation and loading of custom CUDA kernels for LTX Video operations, including pixel normalization and inplace addition operations.
+
+## Overview
+
+The kernel compilation system automatically compiles CUDA kernels on first use and caches them for subsequent runs. It uses checksums to detect changes and recompile when necessary.
+
+## Environment Variables
+
+### `RUNWARE_LTX_TORCH_COMPILE_DIR`
+Sets the primary directory for storing compiled kernels.
+```bash
+export RUNWARE_LTX_TORCH_COMPILE_DIR="/custom/cache/path"
+```
+
+### `TORCH_EXTENSIONS_DIR`
+Fallback directory if `RUNWARE_LTX_TORCH_COMPILE_DIR` is not set.
+```bash
+export TORCH_EXTENSIONS_DIR="/tmp/torch_extensions"
+```
+
+## Default Cache Location
+
+If no environment variables are set, kernels are cached at:
+```
+~/.cache/torch_extensions/{python_version}_{cuda_version}/
+```
+
+Where:
+- `python_version`: Format `py{major}{minor}{abiflags}` (e.g., `py311`)
+- `cuda_version`: Format `cu{version}` (e.g., `cu118`) or `cpu`
+
+### `RUNWARE_LTX_NO_COMPILE_KERNELS`
+Disables automatic kernel compilation when set to any value.
+```bash
+export RUNWARE_LTX_NO_COMPILE_KERNELS=1  # Disable compilation
+```
+
+## How Kernel Loading Works
+
+1. **Automatic Compilation**: Kernels are compiled automatically when the module is imported (unless `RUNWARE_LTX_NO_COMPILE_KERNELS` is set)
+
+2. **Checksum Validation**: The system creates SHA256 checksums of source files and compiled binaries to detect changes
+
+3. **Caching**: Compiled kernels are stored with their checksums to avoid unnecessary recompilation
+
+4. **Dynamic Loading**: Kernels are attached to the module namespace dynamically after compilation
+
+### Manual Compilation
+```python
+from ltx_video.models.autoencoders.vae_patcher.kernels.compiler import compiled_kernel
+import pathlib
+
+# Compile a specific kernel
+kernel = compiled_kernel(
+    name="pixel_norm",
+    sources=["pixel_norm.cpp", "pixel_norm_cuda.cu"],
+    output_directory=pathlib.Path("/custom/output/dir")
+)
+```
+
+### Disabling Automatic Compilation
+```python
+import os
+os.environ["RUNWARE_LTX_NO_COMPILE_KERNELS"] = "1"
+
+# Now import won't trigger compilation
+from ltx_video.models.autoencoders.vae_patcher.kernels.ops import compile_and_attach_kernels
+
+# Manually compile when needed
+compile_and_attach_kernels()
+```
+
+## Cache Structure
+
+The compilation system creates the following structure:
+```
+{cache_dir}/
+├── pixel_norm/
+│   ├── pixel_norm.so
+│   └── pixel_norm.sha256
+└── inplace_add/
+    ├── inplace_add.so
+    └── inplace_add.sha256
+```
+
+## Requirements
+
+- PyTorch with CUDA support
+- CUDA toolkit installed
+- C++ compiler (gcc/clang)
+- NVCC (NVIDIA CUDA Compiler)
+
+## Development
+
+To add new kernels, update the `SOURCES` dictionary in `compiler.py`:
+```python
+SOURCES = {
+    "new_kernel": [
+        "path/to/new_kernel.cpp",
+        "path/to/new_kernel_cuda.cu"
+    ]
+}
+```
+```

--- a/bin/compile-all-kernels
+++ b/bin/compile-all-kernels
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PKG_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
+
+cd "$PKG_ROOT" || exit 1
+
+./bin/ltx_video --verbose compile-kernels \
+  --arch-list "${TORCH_CUDA_ARCH_LIST:-8.6;9.0}" \
+  $@

--- a/bin/ltx_video
+++ b/bin/ltx_video
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PKG_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
+
+cd "$PKG_ROOT" || exit 1
+
+python -m ltx_video $@

--- a/bin/try-load-all-kernels
+++ b/bin/try-load-all-kernels
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PKG_ROOT="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.."
+
+cd "$PKG_ROOT" || exit 1
+
+python -m ltx_video --verbose load-all-kernels $@

--- a/ltx_video/__main__.py
+++ b/ltx_video/__main__.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+from pathlib import Path
+import ltx_video.models.autoencoders.vae_patcher.kernels.compiler as compiler
+
+
+def parse_command_line():
+    parser = argparse.ArgumentParser(
+        description="LTX Video utility commands",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--verbose", action="store_true", default=False, help="Enable verbose output"
+    )
+
+    commands = parser.add_subparsers(
+        dest="command", help="Available commands", required=True
+    )
+
+    add_compile_kernels_command(commands)
+    add_load_all_kernels_command(commands)
+
+    return parser.parse_args()
+
+
+def add_compile_kernels_command(commands):
+
+    compile_parser = commands.add_parser("compile-kernels", help="Compile CUDA kernels")
+
+    compile_parser.add_argument(
+        "--arch-list",
+        type=str,
+        default=os.environ.get("TORCH_CUDA_ARCH_LIST", "8.6;9.0"),
+        help="CUDA architecture list (semicolon-separated)",
+    )
+
+    compile_parser.add_argument(
+        "--kernels-dir",
+        type=Path,
+        default=Path(compiler.KERNELS_PATH),
+        help="Output directory for compiled kernels",
+    )
+
+    compile_parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        default=False,
+        help="Force rebuild of all kernels, even if they are already compiled",
+    )
+
+
+def add_load_all_kernels_command(commands):
+    load_parser = commands.add_parser(
+        "load-all-kernels", help="Load all compiled CUDA kernels"
+    )
+
+    load_parser.add_argument(
+        "--kernels-dir",
+        type=Path,
+        default=Path(compiler.KERNELS_PATH),
+        help="Output directory for compiled kernels",
+    )
+
+
+def build_console_logger():
+    import logging
+
+    logger = logging.getLogger("ltx_video")
+    logger.setLevel(logging.DEBUG)
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    console_handler.setFormatter(formatter)
+
+    logger.addHandler(console_handler)
+    return logger
+
+
+def main():
+    args = parse_command_line()
+
+    if args.verbose:
+        compiler.logger = build_console_logger()
+
+    if args.command == "compile-kernels":
+        os.environ["TORCH_CUDA_ARCH_LIST"] = args.arch_list
+        compiler.compile_all_kernels(
+            kernels_directory=args.kernels_dir, force_rebuild=args.force_rebuild
+        )
+    elif args.command == "load-all-kernels":
+        compiler.load_all_kernels(kernels_directory=args.kernels_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/ltx_video/models/autoencoders/vae_patcher/kernels/compiler.py
+++ b/ltx_video/models/autoencoders/vae_patcher/kernels/compiler.py
@@ -1,0 +1,262 @@
+import pathlib
+import os
+import sys
+import time
+import logging
+import traceback
+from hashlib import sha256
+
+from torch.utils.cpp_extension import (
+    load,
+    get_compiler_abi_compatibility_and_version,
+    get_cxx_compiler,
+    get_default_build_root,
+)
+import torch.ops
+import torch.version
+from functools import cached_property
+
+version_info = sys.version_info
+cuda_version = (
+    "cpu" if torch.version.cuda is None else f'cu{torch.version.cuda.replace(".", "")}'
+)
+python_version = f"py{version_info.major}{version_info.minor}{sys.abiflags}"
+
+home_dir = pathlib.Path(os.path.expanduser("~"))
+
+KERNELS_PATH = (
+    pathlib.Path(
+        os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")
+        or os.getenv("TORCH_EXTENSIONS_DIR")
+        or get_default_build_root()
+    )
+    / f"{python_version}_{cuda_version}"
+)
+
+SOURCES = {
+    "pixel_norm": [
+        os.path.join(os.path.dirname(__file__), "pixel_norm.cpp"),
+        os.path.join(os.path.dirname(__file__), "pixel_norm_cuda.cu"),
+    ],
+    "inplace_add": [
+        os.path.join(os.path.dirname(__file__), "add_inplace.cpp"),
+        os.path.join(os.path.dirname(__file__), "add_inplace_cuda.cu"),
+    ],
+}
+
+logger = logging.getLogger("null")
+
+
+class CompiledLibrary:
+    name: str
+    sources: list[str]
+    kernel_directory: pathlib.Path
+    output_file: pathlib.Path
+    checksum_file: pathlib.Path
+
+    def __init__(
+        self,
+        name: str,
+        sources: list[str],
+        output_directory: pathlib.Path = KERNELS_PATH,
+        can_rebuild: bool = True,
+        force_rebuild: bool = False,
+    ):
+        if not can_rebuild and force_rebuild:
+            raise ValueError(
+                "Cannot rebuild kernel when can_rebuild is set to False and force_rebuild is True."
+            )
+
+        if len(sources) == 0:
+            raise ValueError("sources must not be empty.")
+
+        self.name = name
+        self.sources = sources
+        self.kernel_directory = pathlib.Path(output_directory / name)
+        self.output_file = self.kernel_directory / f"{name}.so"
+        self.checksum_file = self.kernel_directory.with_suffix(".sha256")
+        self.can_build = can_rebuild
+        self.force_build = force_rebuild
+
+    @cached_property
+    def library(self):
+        if self.already_compiled():
+            logger.info(
+                f"Kernel {self.name} is already compiled and up-to-date at {self.output_file}."
+            )
+            return self.compiled_library()
+        else:
+            logger.debug(f"Compiling kernel {self.name} with sources: {self.sources}")
+            return self.compile()
+
+    @property
+    def checksum(self) -> str | None:
+        if not self.checksum_file.exists():
+            return None
+        return self.checksum_file.read_text()
+
+    @cached_property
+    def expected_sources_checksum(self) -> str:
+        return self.expected_checksum_hasher.hexdigest()
+
+    @property
+    def expected_checksum(self) -> str | None:
+        expected_checksum_hasher = self.expected_checksum_hasher
+
+        if self.output_file.exists():
+            expected_checksum_hasher.update(self.output_file.read_bytes())
+            return expected_checksum_hasher.hexdigest()
+        else:
+            return None
+
+    @property
+    def expected_checksum_hasher(self):
+        return self._expected_checksum_hasher.copy()
+
+    @cached_property
+    def _expected_checksum_hasher(self):
+        expected_checksum_hasher = sha256()
+
+        for source in self.sources:
+            bytes = pathlib.Path(source).read_bytes()
+            expected_checksum_hasher.update(bytes)
+
+        return expected_checksum_hasher
+
+    def already_compiled(self) -> bool:
+        if self.force_build:
+            logger.debug(
+                f"Force rebuild is enabled. Will compile kernel {self.name} from sources."
+            )
+            return False
+
+        expected = self.expected_checksum
+        existing_checksum = self.checksum
+
+        if expected is None:
+            logger.debug(
+                f"Output file {self.output_file} does not exist. Will compile from sources. Checksums will not match."
+            )
+            return False
+
+        if existing_checksum is None:
+            logger.debug(
+                f"Checksum file {self.checksum_file} does not exist. Will compile from sources. Checksums will not match."
+            )
+            return False
+
+        if existing_checksum == expected:
+            return True
+
+        logger.warning(
+            f"Kernel {self.name} is not up-to-date. Expected checksum: {expected}, existing checksum: {existing_checksum}. Will compile from sources most likely."
+        )
+        return False
+
+    def compile(self):
+        self.ensure_can_compile()
+
+        self.kernel_directory.mkdir(exist_ok=True, parents=True)
+
+        if self.force_build and self.output_file.exists():
+            logger.debug(
+                f"Removing existing output file {self.output_file} due to force rebuild."
+            )
+            self.output_file.unlink()
+
+        start_time = time.time()
+        res = load(
+            self.name,
+            sources=self.sources,
+            build_directory=f"{self.kernel_directory.absolute()}",
+        )
+        logger.debug(
+            f"Kernel {self.name} compiled in {time.time() - start_time:.2f} seconds"
+        )
+
+        if not self.output_file.exists():
+            raise RuntimeError(
+                f"Failed to compile kernel {self.name}. Output file {self.output_file} does not exist."
+            )
+
+        hasher = self.expected_checksum_hasher
+        hasher.update(self.output_file.read_bytes())
+        self.checksum_file.write_text(hasher.hexdigest())
+
+        return res
+
+    def ensure_can_compile(self):
+        if not self.can_build:
+            raise RuntimeError(
+                f"Kernel {self.name} is not compiled and allow_rebuild is set to False. Cannot compile."
+            )
+
+        status, version = get_compiler_abi_compatibility_and_version(get_cxx_compiler())
+        if not status:
+            raise RuntimeError(
+                f"Compiler is not compatible with the current platform. Cannot compile kernel {self.name}."
+            )
+
+        logger.info(f"Compiler ABI compatibility status: {status}, version: {version}")
+
+    def compiled_library(self):
+        if not self.output_file.exists():
+            raise RuntimeError(
+                f"Kernel {self.name} is not compiled. Output file {self.output_file} does not exist."
+            )
+
+        torch.ops.load_library(self.output_file)
+        return torch.ops.__getattr__(self.name)
+
+
+def compile_all_kernels(
+    kernels_directory: pathlib.Path = KERNELS_PATH, force_rebuild: bool = False
+):
+    if not kernels_directory.exists():
+        kernels_directory.mkdir(exist_ok=True, parents=True)
+
+    for name, sources in SOURCES.items():
+        try:
+            kernel = CompiledLibrary(
+                name=name,
+                sources=sources,
+                output_directory=kernels_directory,
+                can_rebuild=True,
+                force_rebuild=force_rebuild,
+            )
+            setattr(sys.modules[__name__], name, kernel.library)
+        except Exception as e:
+            logger.error(f"Failed to compile kernel {name}: {e}")
+            raise
+
+
+def load_all_kernels(kernels_directory: pathlib.Path = KERNELS_PATH):
+    if not kernels_directory.exists():
+        raise RuntimeError(
+            f"Kernels directory {kernels_directory} does not exist. Cannot load kernels."
+        )
+
+    failed_kernels = {}
+
+    for name, sources in SOURCES.items():
+        try:
+            CompiledLibrary(
+                name=name,
+                sources=sources,
+                output_directory=kernels_directory,
+                can_rebuild=False,
+            ).library
+        except Exception as e:
+            trace = traceback.format_exc()
+            failed_kernels[name] = {
+                "error": str(e),
+                "type": type(e).__name__,
+                "traceback": trace,
+            }
+
+    if len(failed_kernels) > 0:
+        error_details = []
+        for kernel_name, error_info in failed_kernels.items():
+            error_details.append(f"Kernel '{kernel_name}':\n{error_info['traceback']}")
+
+        raise RuntimeError("Failed to load kernels:\n" + "\n".join(error_details))

--- a/ltx_video/models/autoencoders/vae_patcher/kernels/ops.py
+++ b/ltx_video/models/autoencoders/vae_patcher/kernels/ops.py
@@ -1,58 +1,20 @@
-from hashlib import sha256
 import os
-import pathlib
-
-from torch.utils.cpp_extension import load
-import torch.version
 import sys
 
-cu_str = ('cpu' if torch.version.cuda is None else
-                  f'cu{torch.version.cuda.replace(".", "")}')
-python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
+from .compiler import SOURCES, CompiledLibrary
 
 pixel_norm = None
 inplace_add = None
 
 
-source_list_pixel_norm = [
-    os.path.join(os.path.dirname(__file__), "pixel_norm.cpp"),
-    os.path.join(os.path.dirname(__file__), "pixel_norm_cuda.cu"),
-]
+def compile_and_attach_kernels():
+    for name, source_files in SOURCES.items():
+        kernel = CompiledLibrary(name=name, sources=source_files, can_rebuild=False)
+        setattr(sys.modules[__name__], name, kernel.library)
 
-source_list_inplace_add = [
-    os.path.join(os.path.dirname(__file__), "add_inplace.cpp"),
-    os.path.join(os.path.dirname(__file__), "add_inplace_cuda.cu"),
-]
-
-home_dir = pathlib.Path(os.path.expanduser("~"))
-build_repo_dir = pathlib.Path(
-    os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")  # mutable path for prod build
-    or os.getenv("TORCH_EXTENSIONS_DIR")  # default path specified globally
-    or home_dir / ".cache" / "torch_extensions"  # default extension path, to avoid recompilation for dev
-) / f"{python_version}_{cu_str}"
-
-build_repo_dir.mkdir(parents=True, exist_ok=True)  # avoid nvcc crash
 
 if not os.getenv("RUNWARE_LTX_NO_COMPILE_KERNELS"):
-    for (name, src_l) in [
-        ("pixel_norm", source_list_pixel_norm),
-        ("inplace_add", source_list_inplace_add)
-    ]:
-        hasher = sha256()
-        for f in src_l:
-            hasher.update(pathlib.Path(f).read_bytes())
-        hd = hasher.hexdigest()
-        if not (saved_sha := build_repo_dir / name / ".sha256").exists() or saved_sha.read_text() != hd:
-            so = load(
-                name=name,
-                sources=src_l,
-                build_directory=build_repo_dir,
-            )
-            saved_sha.write_text(hd)
-        else:
-            import torch.ops
-            so = torch.ops.load_library(build_repo_dir / name / f"{name}.so")
-        setattr(sys.modules[__name__], name, so)  # save globally
+    compile_and_attach_kernels()
 
 
 def pixel_norm_inplace(x, scale, shift, eps=1e-5):

--- a/ltx_video/models/autoencoders/vae_patcher/kernels/ops.py
+++ b/ltx_video/models/autoencoders/vae_patcher/kernels/ops.py
@@ -1,28 +1,62 @@
+from hashlib import sha256
 import os
+import pathlib
 
 from torch.utils.cpp_extension import load
+import torch.version
+import sys
 
-pixel_norm = load(
-    name="pixel_norm",
-    sources=[
-        os.path.join(os.path.dirname(__file__), "pixel_norm.cpp"),
-        os.path.join(os.path.dirname(__file__), "pixel_norm_cuda.cu"),
-    ],
-)
+cu_str = ('cpu' if torch.version.cuda is None else
+                  f'cu{torch.version.cuda.replace(".", "")}')
+python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
+
+pixel_norm = None
+inplace_add = None
+
+
+source_list_pixel_norm = [
+    os.path.join(os.path.dirname(__file__), "pixel_norm.cpp"),
+    os.path.join(os.path.dirname(__file__), "pixel_norm_cuda.cu"),
+]
+
+source_list_inplace_add = [
+    os.path.join(os.path.dirname(__file__), "add_inplace.cpp"),
+    os.path.join(os.path.dirname(__file__), "add_inplace_cuda.cu"),
+]
+
+home_dir = pathlib.Path(os.path.expanduser("~"))
+build_repo_dir = pathlib.Path(
+    os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")  # mutable path for prod build
+    or os.getenv("TORCH_EXTENSIONS_DIR")  # default path specified globally
+    or home_dir / ".cache" / "torch_extensions"  # default extension path, to avoid recompilation for dev
+) / f"{python_version}_{cu_str}"
+
+build_repo_dir.mkdir(parents=True, exist_ok=True)  # avoid nvcc crash
+
+for (name, src_l) in [
+    ("pixel_norm", source_list_pixel_norm),
+    ("inplace_add", source_list_inplace_add)
+]:
+    hasher = sha256()
+    for f in src_l:
+        hasher.update(pathlib.Path(f).read_bytes())
+    hd = hasher.hexdigest()
+    if not (saved_sha := build_repo_dir / name / ".sha256").exists() or saved_sha.read_text() != hd:
+        so = load(
+            name=name,
+            sources=src_l,
+            build_directory=build_repo_dir,
+        )
+        saved_sha.write_text(hd)
+    else:
+        import torch.ops
+        so = torch.ops.load_library(build_repo_dir / name / f"{name}.so")
+    setattr(sys.modules[__name__], name, so)  # save globally
 
 
 def pixel_norm_inplace(x, scale, shift, eps=1e-5):
-    return pixel_norm.pixel_norm_inplace(x, scale, shift, eps)
-
-
-inplace_add = load(
-    name="inplace_add",
-    sources=[
-        os.path.join(os.path.dirname(__file__), "add_inplace.cpp"),
-        os.path.join(os.path.dirname(__file__), "add_inplace_cuda.cu"),
-    ],
-)
+    return pixel_norm.pixel_norm_inplace(x, scale, shift, eps)  # type: ignore - guaranteed to be there
 
 
 def add_inplace(x, workspace, offset):
-    return inplace_add.inplace_add(x, workspace, offset)
+    return inplace_add.inplace_add(x, workspace, offset)  # type: ignore - guaranteed to be there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent"
 ]
-dependencies = [
-    "torch>=2.1.0",
-    "diffusers>=0.28.2",
-    "transformers>=4.47.2,<4.52.0",
-    "sentencepiece>=0.1.96",
-    "huggingface-hub~=0.30",
-    "einops",
-    "timm"
-]
+dynamic = ["dependencies"]
 
 [project.optional-dependencies]
 inference = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "torch>=2.1.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,4 @@
-from hashlib import sha256
-import os
-import pathlib
 from setuptools import setup
-from torch.utils.cpp_extension import load
-
-import torch.version
-import sys
-
-BASE_PATH = pathlib.Path(__file__).parent
-KERNELS_REPO = BASE_PATH / "ltx_video" / "models" / "autoencoders" / "vae_patcher" / "kernels"
-
-cu_str = ('cpu' if torch.version.cuda is None else
-                  f'cu{torch.version.cuda.replace(".", "")}')
-python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
 
 dependencies = [
     "torch>=2.1.0",
@@ -21,56 +7,12 @@ dependencies = [
     "sentencepiece>=0.1.96",
     "huggingface-hub~=0.30",
     "einops",
-    "timm"
-] if not os.getenv("RUNWARE_LTX_BUILD_STAGE") else []
-print(f"{dependencies=}")
-
-home_dir = pathlib.Path(os.path.expanduser("~"))
-build_repo_dir = pathlib.Path(
-    os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")  # mutable path for prod build
-    or os.getenv("TORCH_EXTENSIONS_DIR")  # default path specified globally
-    or home_dir / ".cache" / "torch_extensions"  # default extension path, to avoid recompilation for dev
-) / f"{python_version}_{cu_str}"
-
-
-
-def compile_object(name: str, src: list[str]):
-    build_directory=build_repo_dir / name
-    stored_hash = None
-    pathlib.Path(build_directory).mkdir(exist_ok=True, parents=True)
-    stored_hash = pathlib.Path(build_directory, ".sha256")
-    hasher = sha256()
-    [hasher.update(pathlib.Path(i).read_bytes()) for i in src]
-    stored_digest = None
-    if not stored_hash or not stored_hash.exists() or (stored_digest := stored_hash.read_text()) != hasher.hexdigest():
-        print(name, hasher.hexdigest(), stored_digest)
-        res = load(
-            name,
-            sources=src,
-            build_directory=build_directory,
-        )
-        if build_directory and stored_hash:
-            stored_hash.write_text(hasher.hexdigest())
-        return res
+    "timm",
+    "ninja", # For compiling custom C++/CUDA extensions
+]
 
 
 if __name__ == "__main__":
-    if not os.getenv("RUNWARE_LTX_NO_COMPILE_KERNELS"):
-        compile_object(
-            name="pixel_norm",
-            src=[
-                str(KERNELS_REPO / "pixel_norm.cpp"),
-                str(KERNELS_REPO / "pixel_norm_cuda.cu"),
-            ],
-        )
-        compile_object(
-            name="inplace_add",
-            src=[
-                str(KERNELS_REPO / "add_inplace.cpp"),
-                str(KERNELS_REPO / "add_inplace_cuda.cu"),
-            ],
-        )
     setup(
         install_requires=dependencies
     )
-

--- a/setup.py
+++ b/setup.py
@@ -48,19 +48,20 @@ def compile_object(name: str, src: list[str]):
 
 
 if __name__ == "__main__":
-    compile_object(
-        name="pixel_norm",
-        src=[
-            str(KERNELS_REPO / "pixel_norm.cpp"),
-            str(KERNELS_REPO / "pixel_norm_cuda.cu"),
-        ],
-    )
-    compile_object(
-        name="inplace_add",
-        src=[
-            str(KERNELS_REPO / "add_inplace.cpp"),
-            str(KERNELS_REPO / "add_inplace_cuda.cu"),
-        ],
-    )
+    if not os.getenv("RUNWARE_LTX_NO_COMPILE_KERNELS"):
+        compile_object(
+            name="pixel_norm",
+            src=[
+                str(KERNELS_REPO / "pixel_norm.cpp"),
+                str(KERNELS_REPO / "pixel_norm_cuda.cu"),
+            ],
+        )
+        compile_object(
+            name="inplace_add",
+            src=[
+                str(KERNELS_REPO / "add_inplace.cpp"),
+                str(KERNELS_REPO / "add_inplace_cuda.cu"),
+            ],
+        )
     setup()
 

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,6 @@ from torch.utils.cpp_extension import load
 import torch.version
 import sys
 
-
-build_dir = os.getenv("RUNWARE_TORCH_COMPILE_DIR")
-if build_dir:
-    pathlib.Path(build_dir).mkdir(exist_ok=True, parents=True)
 BASE_PATH = pathlib.Path(__file__).parent
 KERNELS_REPO = BASE_PATH / "ltx_video" / "models" / "autoencoders" / "vae_patcher" / "kernels"
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,66 @@
+from hashlib import sha256
+import os
+import pathlib
+from setuptools import setup
+from torch.utils.cpp_extension import load
+
+import torch.version
+import sys
+
+
+build_dir = os.getenv("RUNWARE_TORCH_COMPILE_DIR")
+if build_dir:
+    pathlib.Path(build_dir).mkdir(exist_ok=True, parents=True)
+BASE_PATH = pathlib.Path(__file__).parent
+KERNELS_REPO = BASE_PATH / "ltx_video" / "models" / "autoencoders" / "vae_patcher" / "kernels"
+
+cu_str = ('cpu' if torch.version.cuda is None else
+                  f'cu{torch.version.cuda.replace(".", "")}')
+python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
+
+home_dir = pathlib.Path(os.path.expanduser("~"))
+build_repo_dir = pathlib.Path(
+    os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")  # mutable path for prod build
+    or os.getenv("TORCH_EXTENSIONS_DIR")  # default path specified globally
+    or home_dir / ".cache" / "torch_extensions"  # default extension path, to avoid recompilation for dev
+) / f"{python_version}_{cu_str}"
+
+
+
+def compile_object(name: str, src: list[str]):
+    build_directory=build_repo_dir / name
+    stored_hash = None
+    pathlib.Path(build_directory).mkdir(exist_ok=True, parents=True)
+    stored_hash = pathlib.Path(build_directory, ".sha256")
+    hasher = sha256()
+    [hasher.update(pathlib.Path(i).read_bytes()) for i in src]
+    stored_digest = None
+    if not stored_hash or not stored_hash.exists() or (stored_digest := stored_hash.read_text()) != hasher.hexdigest():
+        print(name, hasher.hexdigest(), stored_digest)
+        res = load(
+            name,
+            sources=src,
+            build_directory=build_directory,
+        )
+        if build_directory and stored_hash:
+            stored_hash.write_text(hasher.hexdigest())
+        return res
+
+
+if __name__ == "__main__":
+    compile_object(
+        name="pixel_norm",
+        src=[
+            str(KERNELS_REPO / "pixel_norm.cpp"),
+            str(KERNELS_REPO / "pixel_norm_cuda.cu"),
+        ],
+    )
+    compile_object(
+        name="inplace_add",
+        src=[
+            str(KERNELS_REPO / "add_inplace.cpp"),
+            str(KERNELS_REPO / "add_inplace_cuda.cu"),
+        ],
+    )
+    setup()
+

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,17 @@ cu_str = ('cpu' if torch.version.cuda is None else
                   f'cu{torch.version.cuda.replace(".", "")}')
 python_version = f'py{sys.version_info.major}{sys.version_info.minor}{getattr(sys, "abiflags", "")}'
 
+dependencies = [
+    "torch>=2.1.0",
+    "diffusers>=0.28.2",
+    "transformers>=4.47.2,<4.52.0",
+    "sentencepiece>=0.1.96",
+    "huggingface-hub~=0.30",
+    "einops",
+    "timm"
+] if not os.getenv("RUNWARE_LTX_BUILD_STAGE") else []
+print(f"{dependencies=}")
+
 home_dir = pathlib.Path(os.path.expanduser("~"))
 build_repo_dir = pathlib.Path(
     os.getenv("RUNWARE_LTX_TORCH_COMPILE_DIR")  # mutable path for prod build
@@ -63,5 +74,7 @@ if __name__ == "__main__":
                 str(KERNELS_REPO / "add_inplace_cuda.cu"),
             ],
         )
-    setup()
+    setup(
+        install_requires=dependencies
+    )
 

--- a/tests/fixtures/compilation/kernel.cpp
+++ b/tests/fixtures/compilation/kernel.cpp
@@ -1,0 +1,7 @@
+#include <torch/extension.h>
+
+torch::Tensor test_function(torch::Tensor input) { return input; }
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("test_function", &test_function, "Test function");
+}

--- a/tests/fixtures/compilation/kernel_cuda.cu
+++ b/tests/fixtures/compilation/kernel_cuda.cu
@@ -1,0 +1,6 @@
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+__global__ void test_kernel(float *input, float *output, int size) {}
+
+torch::Tensor test_cuda_function(torch::Tensor input) { return input + 1; }

--- a/tests/test_cuda_kernel_compilation.py
+++ b/tests/test_cuda_kernel_compilation.py
@@ -1,0 +1,404 @@
+import pytest
+import pathlib
+import os
+import tempfile
+import shutil
+from hashlib import sha256
+from pathlib import Path
+
+from unittest.mock import Mock, patch
+from torch.utils.cpp_extension import (
+    get_compiler_abi_compatibility_and_version,
+    _check_cuda_version,
+    get_cxx_compiler,
+)
+from ltx_video.models.autoencoders.vae_patcher.kernels.compiler import CompiledLibrary
+import subprocess
+
+if os.environ.get("TORCH_CUDA_ARCH_LIST") is None:
+    os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0"
+
+
+@pytest.fixture(scope="session")
+def compilation_fixtures() -> Path:
+    return Path(__file__).parent / "fixtures" / "compilation"
+
+
+@pytest.fixture
+def test_kernel_sources(compilation_fixtures):
+    sources = [
+        compilation_fixtures / "kernel.cpp",
+        compilation_fixtures / "kernel_cuda.cu",
+    ]
+    return sources
+
+
+class TestCompiledLibrary:
+
+    @pytest.fixture
+    def temp_dir(self):
+        temp_dir = pathlib.Path(tempfile.mkdtemp())
+        yield temp_dir
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @pytest.fixture
+    def mock_compiled_library(self):
+        mock_lib = Mock()
+        mock_lib.test_function = Mock(return_value="test_result")
+        return mock_lib
+
+    def test_init_basic(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary(
+            name="test_kernel", sources=test_kernel_sources, output_directory=temp_dir
+        )
+
+        assert lib.name == "test_kernel"
+        assert lib.sources == test_kernel_sources
+        assert lib.kernel_directory == temp_dir / "test_kernel"
+        assert lib.output_file == temp_dir / "test_kernel" / "test_kernel.so"
+        assert lib.checksum_file == (temp_dir / "test_kernel").with_suffix(".sha256")
+        assert lib.can_build is True
+        assert lib.force_build is False
+
+    def test_init_with_custom_arguments(self, test_kernel_sources):
+        lib = CompiledLibrary(
+            name="custom_kernel",
+            sources=test_kernel_sources,
+            can_rebuild=False,
+            force_rebuild=False,
+        )
+
+        assert lib.can_build is False
+        assert lib.force_build is False
+
+    def test_init_conflicting_arguments_args(self, test_kernel_sources):
+        with pytest.raises(
+            ValueError,
+            match="Cannot rebuild kernel when can_rebuild is set to False and force_rebuild is True.",
+        ):
+            CompiledLibrary(
+                name="test_kernel",
+                sources=test_kernel_sources,
+                can_rebuild=False,
+                force_rebuild=True,
+            )
+
+    def test_expected_sources_checksum(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        expected_hasher = sha256()
+        for source in test_kernel_sources:
+            expected_hasher.update(pathlib.Path(source).read_bytes())
+        expected = expected_hasher.hexdigest()
+
+        assert lib.expected_sources_checksum == expected
+
+    def test_expected_checksum_hasher_copy(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        hasher1 = lib.expected_checksum_hasher
+        hasher2 = lib.expected_checksum_hasher
+
+        assert hasher1 is not hasher2
+        assert hasher1.hexdigest() == hasher2.hexdigest()
+
+    def test_checksum_file_not_exists(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+        assert lib.checksum is None
+
+    def test_checksum_file_exists(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        test_checksum = "abc123"
+        lib.checksum_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.checksum_file.write_text(test_checksum)
+
+        assert lib.checksum == test_checksum
+
+    def test_expected_checksum_no_output_file(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+        assert lib.expected_checksum is None
+
+    def test_expected_checksum_with_output_file(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock compiled library")
+
+        expected_hasher = sha256()
+        for source in test_kernel_sources:
+            expected_hasher.update(pathlib.Path(source).read_bytes())
+        expected_hasher.update(lib.output_file.read_bytes())
+
+        assert lib.expected_checksum == expected_hasher.hexdigest()
+
+    def test_already_compiled_no_output_file(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+        assert lib.already_compiled() is False
+
+    def test_already_compiled_no_checksum_file(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock library")
+
+        assert lib.already_compiled() is False
+
+    def test_already_compiled_checksum_mismatch(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock library")
+        lib.checksum_file.write_text("wrong_checksum")
+
+        assert lib.already_compiled() is False
+
+    def test_already_compiled_checksum_match(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock library")
+
+        expected_hasher = sha256()
+        for source in test_kernel_sources:
+            expected_hasher.update(pathlib.Path(source).read_bytes())
+        expected_hasher.update(lib.output_file.read_bytes())
+        lib.checksum_file.write_text(expected_hasher.hexdigest())
+
+        assert lib.already_compiled() is True
+
+    def test_ensure_can_compile_not_allowed(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir, can_rebuild=False)
+
+        with pytest.raises(
+            RuntimeError, match="is not compiled and allow_rebuild is set to False"
+        ):
+            lib.ensure_can_compile()
+
+    def test_ensure_can_compile_success(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.ensure_can_compile()
+
+    @patch("ltx_video.models.autoencoders.vae_patcher.kernels.compiler.load")
+    def test_compile_success(self, mock_load, temp_dir, test_kernel_sources):
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        mock_load.side_effect = lambda *args, **kwargs: (
+            lib.output_file.parent.mkdir(parents=True, exist_ok=True),
+            lib.output_file.write_bytes(b"mock compiled library"),
+            Mock(),
+        )[-1]
+
+        lib.compile()
+
+        assert lib.output_file.exists()
+        assert lib.checksum_file.exists()
+
+    @patch("ltx_video.models.autoencoders.vae_patcher.kernels.compiler.load")
+    @patch("pathlib.Path.exists")
+    def test_compile_output_file_not_created(
+        self, mock_load, mock_exists, temp_dir, test_kernel_sources
+    ):
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+        mock_exists.return_value = False
+        mock_load.return_value = None
+
+        with pytest.raises(RuntimeError, match="Failed to compile kernel test"):
+            lib.compile()
+        mock_load.assert_called_once()
+
+    @patch("torch.ops.load_library")
+    @patch("torch.ops.__getattr__")
+    def test_compiled_library_success(
+        self,
+        mock_getattr,
+        mock_load_library,
+        temp_dir,
+        test_kernel_sources,
+        mock_compiled_library,
+    ):
+        mock_getattr.return_value = mock_compiled_library
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock library")
+
+        result = lib.compiled_library()
+
+        assert result == mock_compiled_library
+        mock_load_library.assert_called_once_with(lib.output_file)
+        mock_getattr.assert_called_once_with("test")
+
+    def test_compiled_library_no_output_file(self, temp_dir, test_kernel_sources):
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        with pytest.raises(RuntimeError, match="Kernel test is not compiled"):
+            lib.compiled_library()
+
+    @patch("torch.utils.cpp_extension.load")
+    @patch("torch.ops.load_library")
+    @patch("torch.ops.__getattr__")
+    def test_library_property_already_compiled(
+        self,
+        mock_getattr,
+        mock_load_library,
+        mock_load,
+        temp_dir,
+        test_kernel_sources,
+        mock_compiled_library,
+    ):
+        mock_getattr.return_value = mock_compiled_library
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        lib.output_file.parent.mkdir(parents=True, exist_ok=True)
+        lib.output_file.write_bytes(b"mock library")
+
+        expected_hasher = sha256()
+        for source in test_kernel_sources:
+            expected_hasher.update(pathlib.Path(source).read_bytes())
+        expected_hasher.update(lib.output_file.read_bytes())
+        lib.checksum_file.write_text(expected_hasher.hexdigest())
+
+        result = lib.library
+
+        assert result == mock_compiled_library
+        mock_load.assert_not_called()
+        mock_load_library.assert_called_once()
+
+    @patch("torch.utils.cpp_extension.load")
+    def test_library_property_needs_compilation(
+        self, mock_load, temp_dir, test_kernel_sources, mock_compiled_library
+    ):
+        mock_load.return_value = mock_compiled_library
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        with patch.object(
+            lib, "compile", return_value=mock_compiled_library
+        ) as mock_compile:
+            result = lib.library
+
+            assert result == mock_compiled_library
+            mock_compile.assert_called_once()
+
+    @patch("torch.utils.cpp_extension.load")
+    def test_library_property_cached(
+        self, mock_load, temp_dir, test_kernel_sources, mock_compiled_library
+    ):
+        mock_load.return_value = mock_compiled_library
+
+        lib = CompiledLibrary("test", test_kernel_sources, temp_dir)
+
+        with patch.object(
+            lib, "compile", return_value=mock_compiled_library
+        ) as mock_compile:
+            result1 = lib.library
+            result2 = lib.library
+
+            assert result1 is result2
+            mock_compile.assert_called_once()
+
+
+class TestCompiledLibraryIntegration:
+
+    @pytest.fixture
+    def integration_temp_dir(self):
+        temp_dir = pathlib.Path(tempfile.mkdtemp())
+        yield temp_dir
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_full_workflow_missing_sources(self, integration_temp_dir):
+        non_existent_sources = [
+            str(integration_temp_dir / "missing.cpp"),
+            str(integration_temp_dir / "missing.cu"),
+        ]
+
+        lib = CompiledLibrary("test", non_existent_sources, integration_temp_dir)
+
+        with pytest.raises(FileNotFoundError):
+            _ = lib.expected_sources_checksum
+
+    @pytest.mark.skipif(not cuda_available(), reason="CUDA not available")
+    def test_real_compilation_environment(
+        self, integration_temp_dir, test_kernel_sources
+    ):
+        lib = CompiledLibrary(
+            name="test_kernel",
+            sources=test_kernel_sources,
+            output_directory=integration_temp_dir,
+        )
+
+        compiled_lib = lib.library
+        assert compiled_lib is not None
+
+
+class TestCompiledLibraryEdgeCases:
+
+    def test_empty_sources_list(self, tmp_path):
+        with pytest.raises(Exception):
+            lib = CompiledLibrary("test", [], tmp_path)
+            _ = lib.expected_sources_checksum
+
+    def test_permission_denied_output_directory(self):
+        read_only_dir = pathlib.Path("/root")  # Typically not writable
+        if read_only_dir.exists() and not os.access(read_only_dir, os.W_OK):
+            sources = ["test.cpp"]
+            lib = CompiledLibrary("test", sources, read_only_dir)
+
+            with patch("torch.cuda.is_available", return_value=True):
+                with pytest.raises(Exception):
+                    lib.compile()
+
+    def test_concurrent_access(self, tmp_path):
+        source_file = tmp_path / "test.cpp"
+        source_file.write_text("// test")
+
+        lib = CompiledLibrary("test", [str(source_file)], tmp_path)
+
+        checksum1 = lib.expected_sources_checksum
+        checksum2 = lib.expected_sources_checksum
+
+        assert checksum1 == checksum2
+        assert checksum1 is checksum2
+
+
+def cxx_compiler_major_version():
+    try:
+        output = subprocess.check_output(
+            [get_cxx_compiler(), "--version"], stderr=subprocess.STDOUT
+        )
+        version_line = output.decode().splitlines()[0]
+        version = int(version_line.split()[2].split(".")[0])
+        return version
+    except Exception as e:
+        print(f"Error getting GCC version: {e}")
+        return None
+
+
+def cuda_available():
+    cxx_major_version = cxx_compiler_major_version()
+    if not cxx_major_version:
+        return False
+    if cxx_major_version > 14:
+        return False
+    try:
+        ok, torch_version = get_compiler_abi_compatibility_and_version(
+            get_cxx_compiler()
+        )
+        if not ok:
+            return False
+
+        _check_cuda_version(get_cxx_compiler(), torch_version)
+        return True
+
+    except:
+        return False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--disable-warnings"])


### PR DESCRIPTION
All envs:
`RUNWARE_LTX_NO_COMPILE_KERNELS` - disable compilation
`RUNWARE_LTX_TORCH_COMPILE_DIR` - specify artifacts output dir [build dir]
`TORCH_EXTENSIONS_DIR` - global torch compilation dir [all extensions across all dependencies will be there]

At the compile stage:
```
RUNWARE_LTX_BUILD_STAGE=1 RUNWARE_LTX_TORCH_COMPILE_DIR=<some-dir, by default torch uses ~/.cache/torch_extensions/> uv pip install git+<this repo>
```

To make it verbose output add -v after uv:
```
RUNWARE_LTX_BUILD_STAGE=1 RUNWARE_LTX_TORCH_COMPILE_DIR=<some-dir, by default torch uses ~/.cache/torch_extensions/> uv -v pip install git+<this repo>
```

At the install stage:
```
RUNWARE_LTX_NO_COMPILE_KERNELS=1 uv pip install git+<this repo>
```

For sd-base-api:
```
RUNWARE_LTX_NO_COMPILE_KERNELS=1 uv sync
```
OR
```
RUNWARE_LTX_NO_COMPILE_KERNELS=1 pip install -r requirements.txt
```
OR
```
RUNWARE_LTX_NO_COMPILE_KERNELS=1 uv pip install -r requirements.txt
```